### PR TITLE
add verbose restyle typing

### DIFF
--- a/src/Message.tsx
+++ b/src/Message.tsx
@@ -1,18 +1,34 @@
 import {
+  AllProps,
   composeRestyleFunctions,
   createVariant,
   useRestyle,
+  VariantProps,
 } from '@shopify/restyle';
 import React from 'react';
-import {Text, View} from 'react-native';
+import {StyleProp, Text, TextStyle, View, ViewStyle} from 'react-native';
+import {Theme} from './styles/base';
 
-const containerVariants = createVariant<any, 'messageContainerVariants'>({
+type RestyleProps = AllProps<Theme> &
+  VariantProps<Theme, 'messageContainerVariants'> &
+  VariantProps<Theme, 'messageTextVariants'>;
+
+type OtherProps = Record<string, any>;
+
+const containerVariants = createVariant<Theme, 'messageContainerVariants'>({
   themeKey: 'messageContainerVariants',
 });
+const composedContainerVariantsFunctions = composeRestyleFunctions<
+  Theme,
+  RestyleProps
+>([containerVariants]);
 
-const textVariants = createVariant<any, 'messageTextVariants'>({
+const textVariants = createVariant<Theme, 'messageTextVariants'>({
   themeKey: 'messageTextVariants',
 });
+const composedTextVariants = composeRestyleFunctions<Theme, RestyleProps>([
+  textVariants,
+]);
 
 const Message = ({
   extraStyles = {},
@@ -20,14 +36,19 @@ const Message = ({
   children,
   variant = 'default',
 }: any) => {
-  const containerStyle = useRestyle(
-    composeRestyleFunctions([containerVariants]),
-    {
-      variant,
-      ...extraStyles,
-    },
-  );
-  const textStyle = useRestyle(composeRestyleFunctions([textVariants]), {
+  const containerStyle = useRestyle<
+    Theme,
+    RestyleProps,
+    OtherProps & {style: StyleProp<ViewStyle>}
+  >(composedContainerVariantsFunctions, {
+    variant,
+    ...extraStyles,
+  });
+  const textStyle = useRestyle<
+    Theme,
+    RestyleProps,
+    OtherProps & {style: StyleProp<TextStyle>}
+  >(composedTextVariants, {
     variant,
     ...extraTextStyles,
   });


### PR DESCRIPTION
1. Add `Theme` to `createVariant` generics
2. Specify generics in `composeRestyleFunctions`
3. Specify generics in `useRestyle`
4. (optional) Move `composeRestyleFunctions` out of the component render function to get a slight performance boost.


Disclaimer: I'm creating this PR as a workaround proposal. In the longer term, I think that `restyle` should improve type inference to avoid having to specify so many generics which are not always easy to understand and provide poor developer experience